### PR TITLE
fixed bug in author_tool

### DIFF
--- a/lib/Galileo/Command/author_tool.pm
+++ b/lib/Galileo/Command/author_tool.pm
@@ -4,7 +4,7 @@ use Mojo::Base 'Mojolicious::Command';
 use DBIx::Class::DeploymentHandler;
 
 sub run {
-  my ($self) = @_;
+  my $self = shift;
 
   my $command = shift || 'generate_install_scripts';
   my $method = $self->can($command) or die "No command: $command\n";


### PR DESCRIPTION
Hi Joel,

 bin/galileo author_tool
 says to me:
 [Wed Jul 17 16:32:26 2013] [debug] Reading config file "/home/holger/workspace/Galileo/galileo.conf".
 No command: Galileo::Command::author_tool=HASH(0x9ce505c)

 after the change it works as expected now

Best regards from Dresden
Holger
