### PR TITLE
add extra renderer paths

### DIFF
--- a/lib/Galileo.pm
+++ b/lib/Galileo.pm
@@ -47,6 +47,7 @@ sub load_config {
       extra_css => [ '/themes/standard.css' ],
       extra_js => [],
       extra_static_paths => ['static'],
+      extra_renderer_paths => ['templates'],
       sanitize => 1,
       secrets => [],
       upload_path => 'uploads',
@@ -75,6 +76,12 @@ sub load_config {
     # convert relative paths to relative one (to home dir)
     $dir = $app->_to_abs($dir);
     push @{ $app->static->paths }, $dir if -d $dir;
+  }
+
+  foreach my $dir ( reverse @{$app->config->{extra_renderer_paths}} ) {
+    # convert relative paths to relative one (to home dir)
+    $dir = $app->_to_abs($dir);
+    unshift @{ $app->renderer->paths }, $dir if -d $dir;
   }
 
   # normalize and make helper for upload directory
@@ -132,7 +139,7 @@ sub startup {
     $app->static->paths->[0] = -d $public ? $public : catdir(dist_dir('Galileo'), 'public');
 
     my $templates = catdir($lib_base, 'templates');
-    $app->renderer->paths->[0] = -d $templates ? $templates : catdir(dist_dir('Galileo'), 'templates');
+    $app->renderer->paths->[-1] = -d $templates ? $templates : catdir(dist_dir('Galileo'), 'templates');
   }
 
   # use commands from Galileo::Command namespace
@@ -317,6 +324,10 @@ Logging in L<Galileo> is the same as in L<Mojolicious|Mojolicious::Lite/Logging>
 =head2 Extra Static Paths
 
 By default, if Galileo detects a folder named F<static> inside the C<GALILEO_HOME> path, that path is added to the list of folders for serving static files. The name of this folder may be changed in the configuration file via the key C<extra_static_paths>, which expects an array reference of strings representing paths. If any path is relative it will be relative to C<GALILEO_HOME>.
+
+=head2 Extra Renderer Paths
+
+By default, if Galileo detects a folder named F<templates> inside the C<GALILEO_HOME> path, that path is added to the list of folders for serving templates. The name of this folder may be changed in the configuration file via the key C<extra_renderer_paths>, which expects an array reference of strings representing paths. If any path is relative it will be relative to C<GALILEO_HOME>.
 
 =head2 Upload Path
 

--- a/lib/Galileo/Command/setup.pm
+++ b/lib/Galileo/Command/setup.pm
@@ -49,7 +49,7 @@ sub run {
 
     # map JSON keys to Perl data
     my %params = map { $_ => scalar $self->param($_) } @params;
-    foreach my $key ( qw/extra_css extra_js extra_static_paths secrets db_options/ ) {
+    foreach my $key ( qw/extra_css extra_js extra_static_paths extra_renderer_paths secrets db_options/ ) {
       $params{$key} = j($params{$key});
     }
 
@@ -200,6 +200,9 @@ __DATA__
 
   %= control_group for => 'files', label => 'Extra Static Paths (JSON array)' => begin
     %= text_field 'extra_static_paths', value => j($config->{extra_static_paths}), class => 'input-block-level'
+  % end
+  %= control_group for => 'files', label => 'Extra Renderer Paths (JSON array)' => begin
+    %= text_field 'extra_renderer_paths', value => j($config->{extra_renderer_paths}), class => 'input-block-level'
   % end
   %= control_group for => 'extra_js', label => 'Extra Javascript Files (JSON array)' => begin
     %= text_field 'extra_js', value => j($config->{extra_js}), class => 'input-block-level'

--- a/t/basic.t
+++ b/t/basic.t
@@ -12,8 +12,46 @@ use File::Temp ();
 
 my $dir = File::Temp->newdir( $ENV{KEEP_TEMP_DIR} ? (CLEANUP => 0) : () );
 $ENV{GALILEO_HOME} = $dir;
-mkpath "$dir/static" or die qq{Can't make directory "$dir/static": $!};
+for ( "$dir/static", "$dir/templates", "$dir/templates/page", "$dir/templates/layouts" ) {
+  mkpath $_ or die qq{Can't make directory "$_": $!};
+}
 spurt "<h1>hello world!</h1>", "$dir/static/helloworld.html";
+spurt <<'END_PAGE', "$dir/templates/page/show.html.ep";
+% layout 'brandnew';
+% my $page_title  = $page->title;
+% title $page_title;
+% content_for banner => $page_title;
+
+<div id="extra-renderer-paths-page"></div>
+<div class="page-contents">
+  <%== $page->html %>
+</div>
+END_PAGE
+spurt <<'END_LAYOUTS', "$dir/templates/layouts/brandnew.html.ep";
+<!DOCTYPE html>
+<html>
+<head>
+  <%= include 'header_common' %>
+</head>
+<body>
+<div id="extra-renderer-paths-layout"></div>
+<div class="container">
+  <div class="page-header">
+    <h1><%= content_for 'banner' %></h1>
+  </div>
+  <div class="row">
+    <div class="span2" id="menus">
+      <%= include 'nav_menu' %>
+      <%= include 'user_menu' %>
+    </div>
+    <div class="span10" id="content">
+      <%= content %>
+    </div>
+  </div>
+</div>
+</body>
+</html>
+END_LAYOUTS
 
 my $t = Galileo::DB::Deploy->create_test_object({test => 1});
 $t->ua->max_redirects(2);
@@ -357,6 +395,16 @@ subtest 'Extra Static Paths' => sub {
   $t->get_ok('/helloworld.html')
     ->status_is(200)
     ->text_is( h1 => 'hello world!' );
+};
+
+subtest 'Extra Renderer Paths' => sub {
+  my $app = $t->app;
+  my $dir = File::Spec->catdir( $app->home_path, "templates" );
+  ok -d $dir, "galileo extra renderer paths";
+  $t->get_ok('/')
+    ->status_is(200)
+    ->element_exists( 'div#extra-renderer-paths-page' )
+    ->element_exists( 'div#extra-renderer-paths-layout' );
 };
 
 subtest 'Logging Out' => sub {


### PR DESCRIPTION
I use Galileo as CMS of our team and customize look and feel for needs. Galileo is cool enough to use and to customize. Of course we use `extra_*` options but it is not enough since we need to edit original templates. This `extra_renderer_paths` option could help people who want to change design but doesn't want to edit Galileo's original template.

But if this is not proper approach for Galileo, please just ignore and close this pull-request. :)
