### PR TITLE
Change cursor to 'move' for labels in nav menu edit

### DIFF
--- a/lib/Galileo/files/public/themes/standard.css
+++ b/lib/Galileo/files/public/themes/standard.css
@@ -18,4 +18,6 @@ body {
   display: block;
 }
 
-
+.label-info {
+  cursor: move;
+}


### PR DESCRIPTION
'move' cursor pointer makes it more obvious you can grab and move page labels
